### PR TITLE
Enable http proxying in flutter env [#100]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Created "Runner-Dev" XCode build environment for dev builds.
+- Enable http proxying in flutter env [#100](https://github.com/rokwire/illinois-app/issues/100)
 
 ### Changed
 - "ios/Runner/GoogleService-Info-Debug/Release.plist" secret file refs updated to "ios/Runner/GoogleService-Info-Dev/Prod.plist".

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -21,7 +21,7 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET" />
-    <application>
+    <application android:networkSecurityConfig="@xml/network_security_config">
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="AIzaSyDtlgQtvHfQEUF98_mAvnV3UVkvv8VbC0o"

--- a/android/app/src/debug/res/xml/network_security_config.xml
+++ b/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>

--- a/lib/service/HttpProxy.dart
+++ b/lib/service/HttpProxy.dart
@@ -39,6 +39,12 @@ class HttpProxy extends Service{
   }
 
   @override
+  Future<void> initService() {
+    _handleChanged();
+    return super.initService();
+  }
+
+  @override
   Set<Service> get serviceDependsOn {
     return Set.from([Storage(),]);
   }

--- a/lib/service/HttpProxy.dart
+++ b/lib/service/HttpProxy.dart
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Board of Trustees of the University of Illinois.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'dart:io';
+
+import 'package:illinois/service/Service.dart';
+import 'package:illinois/service/Storage.dart';
+import 'package:illinois/utils/Utils.dart';
+
+class HttpProxy extends Service{
+  
+  HttpProxy._internal();
+  static final HttpProxy _instance = HttpProxy._internal();
+
+  factory HttpProxy() {
+    return _instance;
+  }
+
+  HttpProxy get instance {
+    return _instance;
+  }
+
+  @override
+  void createService() {
+    super.createService();
+  }
+
+  @override
+  Set<Service> get serviceDependsOn {
+    return Set.from([Storage(),]);
+  }
+
+
+  bool get httpProxyEnabled{
+    return Storage().httpProxyEnabled;
+  }
+
+  set httpProxyEnabled(bool value){
+    if(Storage().httpProxyEnabled != value) {
+      Storage().httpProxyEnabled = value;
+      _handleChanged();
+    }
+  }
+
+  String get httpProxyHost{
+    return Storage().httpProxyHost;
+  }
+
+  set httpProxyHost(String value){
+    if(Storage().httpProxyHost != value) {
+      Storage().httpProxyHost = value;
+      _handleChanged();
+    }
+  }
+
+  String get httpProxyPort{
+    return Storage().httpProxyPort;
+  }
+
+  set httpProxyPort(String value){
+    if(Storage().httpProxyPort != value) {
+      Storage().httpProxyPort = value;
+      _handleChanged();
+    }
+  }
+
+  void _handleChanged(){
+    if(httpProxyEnabled && AppString.isStringNotEmpty(httpProxyHost) && AppString.isStringNotEmpty(httpProxyPort)){
+      HttpOverrides.global = _MyHttpOverrides(host: httpProxyHost, port: httpProxyPort);
+    }
+    else{
+      HttpOverrides.global = null;
+    }
+  }
+}
+
+class _MyHttpOverrides extends HttpOverrides {
+
+  final String host;
+  final String port;
+
+  _MyHttpOverrides({this.host, this.port});
+
+  @override
+  HttpClient createHttpClient(SecurityContext context) {
+    return super.createHttpClient(context)
+      ..findProxy = (uri) {
+        return "PROXY $host:$port;";
+      }
+      ..badCertificateCallback =
+          (X509Certificate cert, String host, int port) => true;
+  }
+}

--- a/lib/service/Service.dart
+++ b/lib/service/Service.dart
@@ -29,6 +29,7 @@ import 'package:illinois/service/DiningService.dart';
 import 'package:illinois/service/FirebaseMessaging.dart';
 import 'package:illinois/service/FlexUI.dart';
 import 'package:illinois/service/GeoFence.dart';
+import 'package:illinois/service/HttpProxy.dart';
 import 'package:illinois/service/IlliniCash.dart';
 import 'package:illinois/service/LiveStats.dart';
 import 'package:illinois/service/Localization.dart';
@@ -82,6 +83,7 @@ class Services {
     
     Crashlytics(),
     Storage(),
+    HttpProxy(),
     Config(),
 
     AppLivecycle(),

--- a/lib/service/Storage.dart
+++ b/lib/service/Storage.dart
@@ -616,4 +616,37 @@ class Storage with Service {
   }
 
   /////////////
+  // Http Proxy
+
+  static const String _httpProxyEnabledKey = 'http_proxy_enabled';
+
+  bool get httpProxyEnabled {
+    return _getBoolWithName(_httpProxyEnabledKey, defaultValue: false);
+  }
+
+  set httpProxyEnabled(bool value) {
+    _setBoolWithName(_httpProxyEnabledKey, value);
+  }
+
+  static const String _httpProxyHostKey = 'http_proxy_host';
+
+  String get httpProxyHost {
+    return _getStringWithName(_httpProxyHostKey);
+  }
+
+  set httpProxyHost(String value) {
+    _setStringWithName(_httpProxyHostKey, value);
+  }
+
+  static const String _httpProxyPortKey = 'http_proxy_port';
+
+  String get httpProxyPort {
+    return _getStringWithName(_httpProxyPortKey);
+  }
+
+  set httpProxyPort(String value) {
+    _setStringWithName(_httpProxyPortKey, value);
+  }
+
+  /////////////
 }

--- a/lib/ui/settings/SettingsDebugPanel.dart
+++ b/lib/ui/settings/SettingsDebugPanel.dart
@@ -30,6 +30,7 @@ import 'package:illinois/service/NotificationService.dart';
 import 'package:illinois/service/User.dart';
 import 'package:illinois/service/Storage.dart';
 import 'package:illinois/ui/events/CreateEventPanel.dart';
+import 'package:illinois/ui/settings/debug/HttpProxySettingsPanel.dart';
 import 'package:illinois/ui/settings/debug/MessagingPanel.dart';
 import 'package:illinois/ui/widgets/HeaderBar.dart';
 import 'package:illinois/ui/widgets/TabBarWidget.dart';
@@ -275,6 +276,16 @@ class _SettingsDebugPanelState extends State<SettingsDebugPanel> implements Noti
                             textColor: Styles().colors.fillColorPrimary,
                             borderColor: Styles().colors.fillColorPrimary,
                             onTap: _onTapClearVoting)),
+                    Padding(padding: EdgeInsets.only(top: 5), child: Container()),
+                    Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 16, vertical: 5),
+                        child: RoundedButton(
+                            label: "Http Proxy",
+                            backgroundColor: Styles().colors.background,
+                            fontSize: 16.0,
+                            textColor: Styles().colors.fillColorPrimary,
+                            borderColor: Styles().colors.fillColorPrimary,
+                            onTap: _onTapHttpProxy)),
                     Padding(padding: EdgeInsets.only(top: 5), child: Container()),
                   ],
                 ),
@@ -541,6 +552,10 @@ class _SettingsDebugPanelState extends State<SettingsDebugPanel> implements Noti
         _selectedEnv = Config().configEnvironment;
       });
     }
+  }
+
+  void _onTapHttpProxy() {
+    Navigator.push(context, CupertinoPageRoute(builder: (context)=>HttpProxySettingsPanel()));
   }
 
   // SettingsListenerMixin

--- a/lib/ui/settings/SettingsDebugPanel.dart
+++ b/lib/ui/settings/SettingsDebugPanel.dart
@@ -58,6 +58,7 @@ class _SettingsDebugPanelState extends State<SettingsDebugPanel> implements Noti
   void initState() {
     
     NotificationService().subscribe(this, [
+      Config.notifyEnvironmentChanged,
       GeoFence.notifyCurrentRegionsUpdated,
       GeoFence.notifyCurrentBeaconsUpdated,
     ]);
@@ -311,6 +312,9 @@ class _SettingsDebugPanelState extends State<SettingsDebugPanel> implements Noti
       setState(() {});
     }
     else if (name == GeoFence.notifyCurrentBeaconsUpdated) {
+      setState(() {});
+    }
+    else if(name == Config.notifyEnvironmentChanged){
       setState(() {});
     }
   }

--- a/lib/ui/settings/SettingsDebugPanel.dart
+++ b/lib/ui/settings/SettingsDebugPanel.dart
@@ -277,15 +277,18 @@ class _SettingsDebugPanelState extends State<SettingsDebugPanel> implements Noti
                             borderColor: Styles().colors.fillColorPrimary,
                             onTap: _onTapClearVoting)),
                     Padding(padding: EdgeInsets.only(top: 5), child: Container()),
-                    Padding(
-                        padding: EdgeInsets.symmetric(horizontal: 16, vertical: 5),
-                        child: RoundedButton(
-                            label: "Http Proxy",
-                            backgroundColor: Styles().colors.background,
-                            fontSize: 16.0,
-                            textColor: Styles().colors.fillColorPrimary,
-                            borderColor: Styles().colors.fillColorPrimary,
-                            onTap: _onTapHttpProxy)),
+                    Visibility(
+                      visible: Config().configEnvironment == ConfigEnvironment.dev,
+                      child: Padding(
+                          padding: EdgeInsets.symmetric(horizontal: 16, vertical: 5),
+                          child: RoundedButton(
+                              label: "Http Proxy",
+                              backgroundColor: Styles().colors.background,
+                              fontSize: 16.0,
+                              textColor: Styles().colors.fillColorPrimary,
+                              borderColor: Styles().colors.fillColorPrimary,
+                              onTap: _onTapHttpProxy)),
+                    ),
                     Padding(padding: EdgeInsets.only(top: 5), child: Container()),
                   ],
                 ),
@@ -555,7 +558,9 @@ class _SettingsDebugPanelState extends State<SettingsDebugPanel> implements Noti
   }
 
   void _onTapHttpProxy() {
-    Navigator.push(context, CupertinoPageRoute(builder: (context)=>HttpProxySettingsPanel()));
+    if(Config().configEnvironment == ConfigEnvironment.dev) {
+      Navigator.push(context, CupertinoPageRoute(builder: (context) => HttpProxySettingsPanel()));
+    }
   }
 
   // SettingsListenerMixin

--- a/lib/ui/settings/debug/HttpProxySettingsPanel.dart
+++ b/lib/ui/settings/debug/HttpProxySettingsPanel.dart
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020 Board of Trustees of the University of Illinois.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:illinois/service/HttpProxy.dart';
+import 'package:illinois/service/Localization.dart';
+import 'package:illinois/service/Styles.dart';
+import 'package:illinois/ui/widgets/HeaderBar.dart';
+import 'package:illinois/ui/widgets/RibbonButton.dart';
+import 'package:illinois/ui/widgets/RoundedButton.dart';
+
+class HttpProxySettingsPanel extends StatefulWidget{
+  _HttpProxySettingsPanelState createState() => _HttpProxySettingsPanelState();
+}
+
+class _HttpProxySettingsPanelState extends State<HttpProxySettingsPanel>{
+
+  bool _proxyEnabled;
+
+  final TextEditingController _hostController = TextEditingController();
+  final TextEditingController _portController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _proxyEnabled = HttpProxy().httpProxyEnabled;
+    _hostController.text = HttpProxy().httpProxyHost;
+    _portController.text = HttpProxy().httpProxyPort;
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _portController.dispose();
+    _hostController.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Styles().colors.surface,
+      appBar: SimpleHeaderBarWithBack(
+        context: context,
+        titleWidget: Text(
+          Localization().getStringEx("panel.debug_http_proxy.header.title", "Http Proxy"),
+          style: TextStyle(color: Colors.white, fontSize: 16, fontFamily: Styles().fontFamilies.extraBold),
+        ),
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: Column(
+            children: [
+              ToggleRibbonButton(label: Localization().getStringEx("panel.debug_http_proxy_enable.button.save.title", "Http Proxy Enabled"), toggled: _proxyEnabled, onTap: (){
+                setState(() {
+                  _proxyEnabled = !_proxyEnabled;
+                });
+              }),
+              Padding(
+                  padding: EdgeInsets.only(left: 12, right: 12, bottom: 12),
+                  child: Semantics(
+                    excludeSemantics: true,
+                    label: Localization().getStringEx("panel.debug_http_proxy.edit.host.title", "Http Proxy Host"),
+                    hint: Localization().getStringEx("panel.debug_http_proxy.edit.host.hint", ""),
+                    value: _hostController.text,
+                    child: TextField(
+                      controller: _hostController,
+                      autofocus: false,
+                      cursorColor: Styles().colors.textBackground,
+                      keyboardType: TextInputType.text,
+                      style: TextStyle(
+                          fontSize: 16,
+                          fontFamily: Styles().fontFamilies.regular,
+                          color: Styles().colors.textBackground),
+                      decoration: InputDecoration(
+                        labelText: Localization().getStringEx("panel.debug_http_proxy.edit.host.title", "Http Proxy Host"),
+                        enabledBorder: OutlineInputBorder(
+                          borderSide: BorderSide(
+                              color: Colors.black,
+                              width: 2.0,
+                              style: BorderStyle.solid),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderSide: BorderSide(color: Colors.black, width: 2.0),
+                        ),
+                      ),
+                    ),
+                  )),
+              Padding(
+                  padding: EdgeInsets.only(left: 12, right: 12, bottom: 12),
+                  child: Semantics(
+                    excludeSemantics: true,
+                    label: Localization().getStringEx("panel.debug_http_proxy.edit.host.title", "Http Proxy Port"),
+                    hint: Localization().getStringEx("panel.debug_http_proxy.edit.host.hint", ""),
+                    value: _portController.text,
+                    child: TextField(
+                      controller: _portController,
+                      autofocus: false,
+                      cursorColor: Styles().colors.textBackground,
+                      keyboardType: TextInputType.text,
+                      style: TextStyle(
+                          fontSize: 16,
+                          fontFamily: Styles().fontFamilies.regular,
+                          color: Styles().colors.textBackground),
+                      decoration: InputDecoration(
+                        labelText: Localization().getStringEx("panel.debug_http_proxy.edit.host.title", "Http Proxy Port"),
+                        enabledBorder: OutlineInputBorder(
+                          borderSide: BorderSide(
+                              color: Colors.black,
+                              width: 2.0,
+                              style: BorderStyle.solid),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderSide: BorderSide(color: Colors.black, width: 2.0),
+                        ),
+                      ),
+                    ),
+                  )),
+              RoundedButton(
+                  label: Localization().getStringEx("panel.debug_http_proxy.button.save.title", "Save"),
+                  backgroundColor: Styles().colors.background,
+                  fontSize: 16.0,
+                  textColor: Styles().colors.fillColorPrimary,
+                  borderColor: Styles().colors.fillColorPrimary,
+                  onTap: ()=> _onTapSave(context))
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _onTapSave(BuildContext context){
+    HttpProxy().httpProxyEnabled = _proxyEnabled;
+    HttpProxy().httpProxyHost = _hostController.text;
+    HttpProxy().httpProxyPort = _portController.text;
+    Navigator.pop(context);
+  }
+}
+
+


### PR DESCRIPTION
The proxy is encapsulated in a separate service and it's eligible for working only on dev env. 
The debug options and panels are accessible only on dev env as well 