### PR TITLE
Feature/issue 616

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Completely removed group's hidden attribute and all related stuff [#611](https://github.com/rokwire/illinois-app/issues/611).
 - GroupsDetailPanel: refresh posts when getting back from posts detail panel [#613](https://github.com/rokwire/illinois-app/issues/613).
+- Do not require user to input event end date for all day events. Calculate it based on start date [#616](https://github.com/rokwire/illinois-app/issues/616).
 
 ## [2.6.10] - 2021-07-26
 ### Changed

--- a/lib/ui/events/CreateEventPanel.dart
+++ b/lib/ui/events/CreateEventPanel.dart
@@ -297,7 +297,7 @@ class _CreateEventPanelState extends State<CreateEventPanel> {
                                              )
                                          ),
                                        ),
-                                    Container(width: 10),
+                                    Visibility(visible: !_allDay, child: Container(width: 10)),
                                     Visibility(visible: !_allDay, child: Expanded(
                                       flex: 1,
                                       child: Semantics(label:Localization().getStringEx("panel.create_event.date_time.start_time.title",'START TIME'),
@@ -358,7 +358,7 @@ class _CreateEventPanelState extends State<CreateEventPanel> {
                                       ],
                                     ),
                                   ),
-                                  Padding(
+                                  Visibility(visible: !_allDay, child: Padding(
                                     padding: EdgeInsets.only(bottom: 16),
                                     child: Row(
                                       mainAxisAlignment:
@@ -475,7 +475,7 @@ class _CreateEventPanelState extends State<CreateEventPanel> {
                                         )),
                                       ],
                                     ),
-                                  ),
+                                  )),
                                   Semantics(label:Localization().getStringEx("panel.create_event.date_time.all_day","All Day"),
                                       hint: Localization().getStringEx("panel.create_event.date_time.all_day.hint",""), toggled: _allDay, excludeSemantics: true, child:
                                   ToggleRibbonButton(
@@ -1821,6 +1821,9 @@ class _CreateEventPanelState extends State<CreateEventPanel> {
           utcTTime?.toUtc(), format: AppDateTime.eventsServerCreateDateTimeFormat, ignoreTimeZone: true);
       event.startDateGmt = utcTTime?.toUtc();
     }
+    if (_allDay && (_startDate != null)) {
+      _endDate = _startDate.add(Duration(days: 1)).subtract(Duration(minutes: 1));
+    }
     if(_endDate!=null) {
       timezone.TZDateTime startTime = AppDateTime().changeTimeZoneToDate(_endDate, timezone.getLocation(_selectedTimeZone));
       timezone.TZDateTime utcTTime = startTime?.toUtc();
@@ -1954,7 +1957,7 @@ class _CreateEventPanelState extends State<CreateEventPanel> {
     bool _titleValidation = AppString.isStringNotEmpty(_eventTitleController.text);
     bool _startDateValidation = _startDate != null;
     bool _startTimeValidation = _startTime != null || _allDay;
-    bool _endDateValidation = _endDate != null;
+    bool _endDateValidation = _endDate != null || _allDay;
     bool _endTimeValidation = _endTime != null || _allDay;
     bool _propperStartEndTimeInterval = (_endDate != null) ? !(_startDate?.isAfter(_endDate) ?? true) : true;
     return _categoryValidation && _titleValidation && _startDateValidation && _startTimeValidation &&
@@ -1967,7 +1970,7 @@ class _CreateEventPanelState extends State<CreateEventPanel> {
         AppString.isStringNotEmpty(_eventTitleController.text);
     bool _startDateValidation = _startDate != null;
     bool _startTimeValidation = _startTime != null || _allDay;
-    bool _endDateValidation = _endDate != null;
+    bool _endDateValidation = _endDate != null || _allDay;
     bool _endTimeValidation = _endTime != null || _allDay;
     bool _propperStartEndTimeInterval = (_endDate != null) ? !(_startDate?.isAfter(_endDate) ?? true) : true;
 //    bool subCategoryIsValid = _subCategoryController.text?.isNotEmpty;


### PR DESCRIPTION
## Description
Do not require user to input end date when creating all day events. Calculate it based on the start date.

**Fixes #616**
