### PR TITLE
Bug/issue 1058

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Do not prompt user to select other group if he is an admin to just one group. [#1057](https://github.com/rokwire/illinois-app/issues/1057).
 - Favorites (star) Button don't work. [#1069](https://github.com/rokwire/illinois-app/issues/1069).
+- Do not present GroupDetailPanel when group event is created. [#1058](https://github.com/rokwire/illinois-app/issues/1058).
 ### Changed
 - Load test locations from content service. [#1068](https://github.com/rokwire/illinois-app/issues/1068).
 

--- a/lib/ui/RootPanel.dart
+++ b/lib/ui/RootPanel.dart
@@ -607,9 +607,13 @@ class _RootPanelState extends State<RootPanel> with TickerProviderStateMixin imp
   }
 
   void _onFirebaseGroupsNotification(param) {
-    if(param is Map<String, dynamic>){
-      String groupId = param["entity_id"];
-      _presentGroupDetailPanel(groupId);
+    if (param is Map<String, dynamic>) {
+      String operation = param['operation'];
+      // Do not present GroupDetail panel when the admin creates event. This breakes the navigation stack when the creator receives FCM notification.
+      if (operation != 'event_created') {
+        String groupId = param["entity_id"];
+        _presentGroupDetailPanel(groupId);
+      }
     }
   }
 

--- a/lib/ui/events/CreateEventPanel.dart
+++ b/lib/ui/events/CreateEventPanel.dart
@@ -1781,8 +1781,19 @@ class _CreateEventPanelState extends State<CreateEventPanel> {
       Event mainEvent = _constructEventFromData();
       Event eventToDisplay;
       Group groupToDisplay;
-      String mainEventId = await ExploreService().postNewEvent(mainEvent);
       List<String> createEventFailedForGroupNames = [];
+      List<Group> otherGroupsToSave;
+
+      // If the event is part of a group - allow the admin to select other groups that one wants to save the event as well.
+      if (hasGroup) {
+        List<Group> otherGroups = await _loadOtherAdminUserGroups();
+        if (AppCollection.isCollectionNotEmpty(otherGroups)) {
+          otherGroupsToSave = await showDialog(context: context, barrierDismissible: false, builder: (_) => _GroupsSelectionPopup(groups: otherGroups));
+        }
+      }
+
+      // Save the initial event and link it to group if it's part of such one.
+      String mainEventId = await ExploreService().postNewEvent(mainEvent);
       if (AppString.isStringNotEmpty(mainEventId)) {
         // Succeeded to create the main event
         if (hasGroup) {
@@ -1803,33 +1814,27 @@ class _CreateEventPanelState extends State<CreateEventPanel> {
         createEventFailedForGroupNames.add(widget.group.title);
       }
 
-      if (hasGroup) {
-        List<Group> otherGroups = await _loadOtherAdminUserGroups();
-        if (AppCollection.isCollectionNotEmpty(otherGroups)) {
-          List<Group> selectedOtherGroups =
-              await showDialog(context: context, barrierDismissible: false, builder: (_) => _GroupsSelectionPopup(groups: otherGroups));
-          if (AppCollection.isCollectionNotEmpty(selectedOtherGroups)) {
-            for (Group group in selectedOtherGroups) {
-              Event groupEvent = Event.fromOther(mainEvent);
-              groupEvent.createdByGroupId = group.id;
-              String groupEventId = await ExploreService().postNewEvent(groupEvent);
-              if (AppString.isStringNotEmpty(groupEventId)) {
-                bool eventLinkedToGroup = await Groups().linkEventToGroup(groupId: groupEvent.createdByGroupId, eventId: groupEventId);
-                if (eventLinkedToGroup) {
-                  // Succeeded to link event to group
-                  if (eventToDisplay == null) {
-                    eventToDisplay = groupEvent;
-                    groupToDisplay = group;
-                  }
-                } else {
-                  // Failed to link event to group
-                  createEventFailedForGroupNames.add(group.title);
-                }
-              } else {
-                // Failed to create event for group
-                createEventFailedForGroupNames.add(group.title);
+      // Save the event to the other selected groups that the user is admin.
+      if (hasGroup && AppCollection.isCollectionNotEmpty(otherGroupsToSave)) {
+        for (Group group in otherGroupsToSave) {
+          Event groupEvent = Event.fromOther(mainEvent);
+          groupEvent.createdByGroupId = group.id;
+          String groupEventId = await ExploreService().postNewEvent(groupEvent);
+          if (AppString.isStringNotEmpty(groupEventId)) {
+            bool eventLinkedToGroup = await Groups().linkEventToGroup(groupId: groupEvent.createdByGroupId, eventId: groupEventId);
+            if (eventLinkedToGroup) {
+              // Succeeded to link event to group
+              if (eventToDisplay == null) {
+                eventToDisplay = groupEvent;
+                groupToDisplay = group;
               }
+            } else {
+              // Failed to link event to group
+              createEventFailedForGroupNames.add(group.title);
             }
+          } else {
+            // Failed to create event for group
+            createEventFailedForGroupNames.add(group.title);
           }
         }
       }
@@ -1848,11 +1853,8 @@ class _CreateEventPanelState extends State<CreateEventPanel> {
       }
 
       if (eventToDisplay != null) {
-        Navigator.push(
-                context, CupertinoPageRoute(builder: (context) => GroupEventDetailPanel(event: eventToDisplay, group: groupToDisplay, previewMode: true)))
-            .then((dynamic data) {
-          Navigator.pop(context);
-        });
+        Navigator.pushReplacement(
+            context, CupertinoPageRoute(builder: (context) => GroupEventDetailPanel(event: eventToDisplay, group: groupToDisplay, previewMode: true)));
       }
     }
   }


### PR DESCRIPTION
## Description
Do not present GroupDetailPanel when group event is created. This breaks the navigation stack when the creator of the event receives a FCM notification.

**Fixes #1058**