### PR TITLE
Release/v3.0.68+1068

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,7 +175,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show buss pass panel for residents [#936](https://github.com/rokwire/illinois-app/issues/936).
 
 ## [3.0.44] - 2021-11-09
-###Fixed 
+### Fixed 
 - Fixed Firebase subscription for Groups Update Settings [#926](https://github.com/rokwire/illinois-app/issues/926).
 
 ## [3.0.43] - 2021-11-08
@@ -189,7 +189,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed 
 - Fix missing image in Group Event Detail Panel [#918](https://github.com/rokwire/illinois-app/issues/918).
 - Hide Dining Specials [#920](https://github.com/rokwire/illinois-app/issues/920).
-
 
 ## [3.0.41] - 2021-11-04
 ### Fixed
@@ -215,7 +214,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Commend out Calendar debug dualog messages [#893](https://github.com/rokwire/illinois-app/issues/893).
 ### Fixed
 - Fixed email signup/login [#832](https://github.com/rokwire/illinois-app/issues/832).
-
 
 ## [3.0.38] - 2021-11-01
 ### Fixed
@@ -254,6 +252,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display all games in Athletics schedule [#857](https://github.com/rokwire/illinois-app/issues/857).
 
 ## [3.0.33] - 2021-10-22
+### Fixed
 - Broken FCM messaging in iOS [#839](https://github.com/rokwire/illinois-app/issues/839).
 
 ## [3.0.32] - 2021-10-22
@@ -458,6 +457,148 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Removed refreshToken parameter from Network calls (not really needed).
 - Repeat 401 failed request only if refreshToken succeeded.
+
+## [2.8.1] - 2021-11-15
+### Changed
+- Rework content loading and processing in GroupsHomePanel [#948](https://github.com/rokwire/illinois-app/issues/948).
+- Validate transfer amount and other CC fields in AddIlliniCash panel [#957](https://github.com/rokwire/illinois-app/issues/957).
+- Do not list rejected groups in "My Groups" tab of GroupsHomePanel [#958](https://github.com/rokwire/illinois-app/issues/958).
+
+## [2.8.0] - 2021-11-12
+### Changed
+- Allow MTD BussPass for residents [#936](https://github.com/rokwire/illinois-app/issues/936).
+- "Safer Illinois" button replaced by "Building Status" button in Browse panel [#952](https://github.com/rokwire/illinois-app/issues/952).
+### Deleted
+- Removed UPACE activity button from Wellness content [#947](https://github.com/rokwire/illinois-app/issues/947).
+
+## [2.7.8] - 2021-11-11
+### Changed
+- Open MyMcKinley web app in WebPanel instead of in external browser [#938](https://github.com/rokwire/illinois-app/issues/938).
+### Added
+- Add Semantics label for Building Access image in IDCardPanel [#881](https://github.com/rokwire/illinois-app/issues/881).
+
+## [2.7.7] - 2021-11-10
+### Added
+- Created building access widget [#932](https://github.com/rokwire/illinois-app/issues/932).
+
+## [2.7.6] - 2021-11-05
+### Fixed
+- Fix wrong update time displayed for group posts [#889](https://github.com/rokwire/illinois-app/issues/889).
+- Fix missing image in Group Event Detail Panel [#918](https://github.com/rokwire/illinois-app/issues/918).
+- Hide Dining Specials [#920](https://github.com/rokwire/illinois-app/issues/920).
+
+## [2.7.5] - 2021-11-04
+### Fixed
+- Broken external browser after switching to Android SDK 30 [#900](https://github.com/rokwire/illinois-app/issues/900).
+- Fix large font in Athletics News [#855](https://github.com/rokwire/illinois-app/issues/855).
+
+## [2.7.4] - 2021-11-03
+### Changed
+- Make the edit controls in phone login in Personal Info panel with white background to indicate that they are editable [#842](https://github.com/rokwire/illinois-app/issues/842).
+- Rename "Student Guide" to "Campus Guide" [#875](https://github.com/rokwire/illinois-app/issues/875).
+- Android: Update to API level 30 [#896](https://github.com/rokwire/illinois-app/issues/896).
+### Fixed
+- RootPanel: fix broken Tab content when recreating the TabBarController [#879](https://github.com/rokwire/illinois-app/issues/879).
+- DINING/RECENTLY VIEWED doesn't show dining schedule accurately [#835](https://github.com/rokwire/illinois-app/issues/835).
+
+## [2.7.3] - 2021-10-22
+### Fixed
+- Fixed spelling in Wallet  [#830](https://github.com/rokwire/illinois-app/issues/830).
+- GroupDetailPanel: Do not reverse group posts when filling the content   [#829](https://github.com/rokwire/illinois-app/issues/829).
+### Changed
+- Groups: update strings [#836](https://github.com/rokwire/illinois-app/issues/836).
+- GroupDetailPanel: place "show older" button at the end of the posts list [#829](https://github.com/rokwire/illinois-app/issues/829).
+### Added
+- Add image to GroupEventCard [#840](https://github.com/rokwire/illinois-app/issues/840).
+
+## [2.7.2] - 2021-10-18
+### Changed
+- Updated again layout of ID Card panel [#819](https://github.com/rokwire/illinois-app/issues/819).
+
+## [2.7.1] - 2021-10-15
+### Changed
+- Updated layout of ID Card panel [#810](https://github.com/rokwire/illinois-app/issues/810).
+
+## [2.7.0] - 2021-10-14
+### Added
+- Added building access status in ID Card panel [#806](https://github.com/rokwire/illinois-app/issues/806).
+
+## [2.6.28] - 2021-09-27
+### Changed
+- Athletics: do not show "Free admission" when there is no value for "tickets" url [#777](https://github.com/rokwire/illinois-app/issues/777).
+
+## [2.6.27] - 2021-09-17
+### Changed
+- Upload images using Content BB. [#763](https://github.com/rokwire/illinois-app/issues/763).
+
+## [2.6.26] - 2021-09-16
+### Fixed
+- Removed wrong "buss" spelling everywhere (display strings, internal names, resource names) [#756](https://github.com/rokwire/illinois-app/issues/756).
+
+## [2.6.25] - 2021-09-02
+### Changed
+- ExplorePanel: remove horizontal scrolling for tabs and filters. [#511](https://github.com/rokwire/illinois-app/issues/511).
+
+## [2.6.24] - 2021-09-01
+### Added
+- Added contacts information in event detail panel [#713](https://github.com/rokwire/illinois-app/issues/713).
+- Added group attributes ito "Request to join" select analytics event [#737](https://github.com/rokwire/illinois-app/issues/737).
+
+## [2.6.23] - 2021-08-30
+### Fixed
+- Remove Converge url action [#292](https://github.com/rokwire/illinois-app/issues/292).
+- AthleticsHomePanel update semantics label for image [#510](https://github.com/rokwire/illinois-app/issues/510).
+- BrowsePanel: improve Large Text support [#511](https://github.com/rokwire/illinois-app/issues/511).
+
+## [2.6.22] - 2021-08-23
+### Fixed
+- Forgetting user information [#705](https://github.com/rokwire/illinois-app/issues/705).
+- Unwanted display of test emergency widget [#710](https://github.com/rokwire/illinois-app/issues/710).
+### Changed
+- Delay creating MapWidget  until needed in Laundry Home, Laundry Detail and Event Schedule panels [#706](https://github.com/rokwire/illinois-app/issues/706).
+
+## [2.6.21] - 2021-08-20
+### Fixed
+- Dining Plan Balance Not Refreshing [#698](https://github.com/rokwire/illinois-app/issues/698).
+### Changed
+- Delay creating MapWidget in ExplorePanel until needed [#701](https://github.com/rokwire/illinois-app/issues/701).
+
+## [2.6.20] - 2021-08-18
+### Changed
+- Update MTD logo [#694](https://github.com/rokwire/illinois-app/issues/694).
+
+## [2.6.19] - 2021-08-16
+### Fixed
+- Handle new line symbols in the html widget [#692](https://github.com/rokwire/illinois-app/issues/692).
+
+## [2.6.18] - 2021-08-12
+### Changed
+- Updated Dining Dollars icon [#682](https://github.com/rokwire/illinois-app/issues/682).
+### Fixed
+- Display group website link for members and admins as well [#681](https://github.com/rokwire/illinois-app/issues/681).
+- Fixed action for StudentGuide library-card feature [#684](https://github.com/rokwire/illinois-app/issues/684).
+- Check in FlexUI whether relevant StudentGuide feature are available before displaying it [#684](https://github.com/rokwire/illinois-app/issues/684).
+- Parsing group membership questions to json [#417](https://github.com/rokwire/illinois-app/issues/417).
+- Fixed onboarding screens that used ScaleableScrollView [#679](https://github.com/rokwire/illinois-app/issues/679).
+
+## [2.6.17] - 2021-08-11
+### Fixed
+- Additional fix which prevents UI blocking if the user cancels the login process[#357](https://github.com/rokwire/illinois-app/issues/357).
+- Display start time for events from Athletics category [#636](https://github.com/rokwire/illinois-app/issues/636).
+- Display options menu in GroupAllEventsPanel for group admins [#637](https://github.com/rokwire/illinois-app/issues/637).
+- Remove check if user is employee when creating group and change permissions error message [#663](https://github.com/rokwire/illinois-app/issues/663).
+### Added
+- Add three new buttons to mental wellness [#674](https://github.com/rokwire/illinois-app/issues/674).
+### Changed
+- Updated Dining Dollars icon [#669](https://github.com/rokwire/illinois-app/issues/669).
+
+## [2.6.16] - 2021-08-04
+### Fixed
+- Allow only users with granted permissions to create a group [#663](https://github.com/rokwire/illinois-app/issues/663).
+
+## [2.6.15] - 2021-08-03
+### Fixed
+- Do not allow editing events for non-group events [#658](https://github.com/rokwire/illinois-app/issues/658).
 
 ## [2.6.14] - 2021-07-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [3.0.67] - 2021-12-14
 ### Changed
 - Updated "Wellness / Emotional / Counseling Center / ACE IT" button action to load guide content [#1129](https://github.com/rokwire/illinois-app/issues/1129).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [3.0.68] - 2021-12-15
 ### Deleted
 - Removed unused iOS background modes from Info.plist [#1137](https://github.com/rokwire/illinois-app/issues/1137).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Deleted
+- Removed unused iOS background modes from Info.plist [#1137](https://github.com/rokwire/illinois-app/issues/1137).
 
 ## [3.0.67] - 2021-12-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Updated "Wellness / Emotional / Counseling Center / ACE IT" button action to load guide content [#1129](https://github.com/rokwire/illinois-app/issues/1129).
 
 ## [3.0.66] - 2021-12-13
 ### Changed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,27 +6,10 @@ Patches for [ **illinois-app** ] will only be applied to the following versions:
 
 | Version | Supported |
 | ------- | ------------------ |
-| 3.0.18 | :white_check_mark: |
-| 3.0.17 | :x: |
-| 3.0.16 | :x: |
-| 3.0.15 | :x: |
-| 3.0.14 | :x: |
-| 3.0.13 | :x: |
-| 3.0.12 | :x: |
-| 3.0.11 | :x: |
-| 3.0.10 | :x: |
-| 3.0.9 | :x: |
-| 3.0.8 | :x: |
-| 3.0.7 | :x: |
-| 3.0.6 | :x: |
-| 3.0.5 | :x: |
-| 3.0.4 | :x: |
-| 3.0.3 | :x: |
-| 3.0.2 | :x: |
-| 3.0.1 | :x: |
-| 3.0.0 | :x: |
-| 2.6.28 | :white_check_mark: |
-| < 2.6.28 | :x: |
+| 3.0.67 | :white_check_mark: |
+| < 3.0.67| :x: |
+| 2.8.1 | :white_check_mark: |
+| < 2.8.1 | :x: |
 
 ## Reporting a Bug or Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Patches for [ **illinois-app** ] will only be applied to the following versions:
 
 | Version | Supported |
 | ------- | ------------------ |
-| 3.0.67 | :white_check_mark: |
-| < 3.0.67| :x: |
+| 3.0.68 | :white_check_mark: |
+| < 3.0.68| :x: |
 | 2.8.1 | :white_check_mark: |
 | < 2.8.1 | :x: |
 

--- a/assets/assets.json
+++ b/assets/assets.json
@@ -1945,7 +1945,7 @@
 							},
 							{
 								"title":"panel.wellness.common.resources.ace_it",
-								"url":"https://counselingcenter.illinois.edu/aceit",
+								"url":"edu.illinois.rokwire://rokwire.illinois.edu/guide_detail?guide_id=drugs.alcohol.help",
 								"icon": "link-out.png",
 								"hint": ""
 							}

--- a/ios/Runner/AppDelegate.m
+++ b/ios/Runner/AppDelegate.m
@@ -756,7 +756,7 @@ UIInterfaceOrientationMask _interfaceOrientationToMask(UIInterfaceOrientation va
 			if (_clLocationManager == nil) {
 				_clLocationManager = [[CLLocationManager alloc] init];
 				_clLocationManager.delegate = self;
-				[_clLocationManager requestAlwaysAuthorization];
+				[_clLocationManager requestWhenInUseAuthorization];
 			}
 		}
 		else {

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -37,6 +37,15 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>com.touchnet.orderahead</string>
+		<string>edu.illinois.covid</string>
+		<string>https</string>
+		<string>http</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -82,8 +91,6 @@
 	<array>
 		<string>bluetooth-central</string>
 		<string>bluetooth-peripheral</string>
-		<string>fetch</string>
-		<string>location</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
@@ -114,14 +121,5 @@
 	<false/>
 	<key>io.flutter.embedded_views_preview</key>
 	<string>YES</string>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>com.touchnet.orderahead</string>
-		<string>edu.illinois.covid</string>
-		<string>https</string>
-		<string>http</string>
-	</array>
-	<key>FirebaseAppDelegateProxyEnabled</key>
-	<false/>
 </dict>
 </plist>

--- a/lib/ui/home/HomeSaferTestLocationsPanel.dart
+++ b/lib/ui/home/HomeSaferTestLocationsPanel.dart
@@ -512,7 +512,7 @@ class HealthServiceLocation {
 
   factory HealthServiceLocation.fromJson(Map<String, dynamic> json) {
     return (json != null) ? HealthServiceLocation(
-      id: json['id'],
+      id: json['_id'],
       name: json['name'],
       contact: json["contact"],
       city: json["city"],
@@ -532,7 +532,7 @@ class HealthServiceLocation {
 
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      '_id': id,
       'name': name,
       'contact': contact,
       'city': city,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: Illinois client application.
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 3.0.67+1067
+version: 3.0.68+1068
 
 environment:
   sdk: ">=2.2.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: Illinois client application.
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 3.0.66+1066
+version: 3.0.67+1067
 
 environment:
   sdk: ">=2.2.0 <3.0.0"


### PR DESCRIPTION
This PR removed location and fetch UIBackgroundModes, Bluetooth background modes still persist since we really use them.

NB: We do not need location services for Poll service. It is needed mostly by GeoFence service but we do not really need them running in background.