### PR TITLE
Issue/3258 hide browse athletics items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Athletics entries in Browse [#3258](https://github.com/rokwire/illinois-app/issues/3258).
 
 ## [4.3.57] - 2023-05-06
 ### Changed

--- a/assets/flexUI.json
+++ b/assets/flexUI.json
@@ -29,7 +29,7 @@
 			"browse.academics": ["gies_checklist", "new_student_checklist", "skills_self_evaluation", "student_courses", "canvas_courses", "campus_reminders", "wellness_todo", "due_date_catalog", "appointments"],
 			"browse.appointments": ["appointments"],
 			"browse.app_help": ["faqs", "feedback", "review", "video_tutorials"],
-			"browse.athletics": ["my_game_day", "sport_events", "my_athletics", "sport_news", "my_news"],
+			"browse.athletics": ["my_game_day", "sport_events", "sport_news"],
 			"browse.safer": ["building_access", "test_locations", "my_mckinley", "wellness_answer_center"],
 			"browse.laundry": ["laundry", "my_laundry"],
 			"browse.campus_guide": ["campus_highlights", "campus_safety_resources", "campus_guide", "my_campus_guide"],

--- a/assets/strings.en.json
+++ b/assets/strings.en.json
@@ -330,7 +330,7 @@
 
     "panel.browse.entry.appointments.appointments.title": "Appointments",
 
-    "panel.browse.entry.athletics.my_game_day.title": "My Game Day",
+    "panel.browse.entry.athletics.my_game_day.title": "Teams",
     "panel.browse.entry.athletics.sport_events.title": "Upcoming Events",
     "panel.browse.entry.athletics.my_athletics.title": "My Events",
     "panel.browse.entry.athletics.sport_news.title": "News",

--- a/assets/strings.es.json
+++ b/assets/strings.es.json
@@ -329,7 +329,7 @@
 
     "panel.browse.entry.appointments.appointments.title": "Equipo",
 
-    "panel.browse.entry.athletics.my_game_day.title": "Mi dia de juego",
+    "panel.browse.entry.athletics.my_game_day.title": "Equipos",
     "panel.browse.entry.athletics.upcoming_games.title": "Próximos Eventos",
     "panel.browse.entry.athletics.my_athletics.title": "Mis eventos",
     "panel.browse.entry.athletics.sport_news.title": "Noticias",

--- a/assets/strings.zh.json
+++ b/assets/strings.zh.json
@@ -329,7 +329,7 @@
 
 	"panel.browse.entry.appointments.appointments.title": "約會",
 
-	"panel.browse.entry.athletics.my_game_day.title": "我的比賽日",
+	"panel.browse.entry.athletics.my_game_day.title": "團隊",
 	"panel.browse.entry.athletics.upcoming_games.title": "接下來的活動",
 	"panel.browse.entry.athletics.my_athletics.title": "我的活動",
 	"panel.browse.entry.athletics.sport_news.title": "消息",


### PR DESCRIPTION
## Description
Remove "My Events" and "My News" from Athletics. Rename "My Game Day" to "Teams".

**Fixes #3258**