### PR TITLE
Issue/3588 rename i card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Rename "i-card" to "Illini ID" in Settings [#3588](https://github.com/rokwire/illinois-app/issues/3588).
 
 ## [5.0.49] - 2023-08-17
 ### Changed

--- a/assets/strings.en.json
+++ b/assets/strings.en.json
@@ -1651,7 +1651,7 @@
     "panel.settings.home.settings.sections.appointments.label": "MyMcKinley Appointments",
     "panel.settings.home.settings.sections.favorites.label": "Customize Favorites",
     "panel.settings.home.settings.sections.assessments.label": "My Assessments",
-    "panel.settings.home.settings.sections.i_card.label": "i-card",
+    "panel.settings.home.settings.sections.i_card.label": "Illini ID",
 
     "panel.settings.home.connect.not_logged_in.title":"Sign in to {{app_title}}",
     "panel.settings.home.connect.not_logged_in.netid.description.part_1": "Are you a ",

--- a/assets/strings.es.json
+++ b/assets/strings.es.json
@@ -1634,7 +1634,7 @@
     "panel.settings.home.settings.sections.appointments.label": "Mis citas de McKinley",
     "panel.settings.home.settings.sections.favorites.label": "Personalizar favoritos",
     "panel.settings.home.settings.sections.assessments.label": "Mis evaluaciones",
-    "panel.settings.home.settings.sections.i_card.label": "i-tarjeta",
+    "panel.settings.home.settings.sections.i_card.label": "Illini ID",
 
     "panel.settings.home.connect.not_logged_in.title":"Inicia sesión en {{app_title}}",
     "panel.settings.home.connect.not_logged_in.netid.description.part_1": "Eres un ",

--- a/assets/strings.zh.json
+++ b/assets/strings.zh.json
@@ -1634,8 +1634,8 @@
 	"panel.settings.home.settings.sections.calendar.label": "我的日曆設置",
 	"panel.settings.home.settings.sections.appointments.label": "我的麥金萊約會",
 	"panel.settings.home.settings.sections.favorites.label": "自定義收藏夾",
-		"panel.settings.home.settings.sections.assessments.label": "我的評估",
-		"panel.settings.home.settings.sections.i_card.label": "i卡",
+	"panel.settings.home.settings.sections.assessments.label": "我的評估",
+	"panel.settings.home.settings.sections.i_card.label": "伊利尼州 ID",
 	
 	"panel.settings.home.connect.not_logged_in.title":"登錄{{app_title}}",
 	"panel.settings.home.connect.not_logged_in.netid.description.part_1": "你是不是一位",

--- a/lib/ui/settings/SettingsHomeContentPanel.dart
+++ b/lib/ui/settings/SettingsHomeContentPanel.dart
@@ -312,7 +312,7 @@ class _SettingsHomeContentPanelState extends State<SettingsHomeContentPanel> imp
       case SettingsContent.assessments:
         return Localization().getStringEx('panel.settings.home.settings.sections.assessments.label', 'My Assessments');
       case SettingsContent.i_card:
-        return Localization().getStringEx('panel.settings.home.settings.sections.i_card.label', 'i-card');
+        return Localization().getStringEx('panel.settings.home.settings.sections.i_card.label', 'Illini ID');
     }
   }
 


### PR DESCRIPTION
## Description
Rename "i-card" to "Illini ID"in Settings.

**Fixes #3588**