### PR TITLE
Issue/5368 stay on root tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Map2: Added Storied Sites [#5344](https://github.com/rokwire/illinois-app/issues/5344).
 - Assistant: Show campus buildings as UI fragments [#5430](https://github.com/rokwire/illinois-app/issues/5430).
+### Changed
+- Do not pop to home panel when switching tabs to Assistant or Wallet [#5368](https://github.com/rokwire/illinois-app/issues/5368).
 
 ## [7.3.8] - 2025-10-06
 ### Added

--- a/lib/ui/RootPanel.dart
+++ b/lib/ui/RootPanel.dart
@@ -782,7 +782,11 @@ class _RootPanelState extends State<RootPanel> with NotificationsListener, Ticke
 
   void _onTabSelectionChanged(int tabIndex) {
     if (mounted) {
-      Navigator.of(context, rootNavigator: true).popUntil((route) => route.isFirst);
+      RootTab? tab = getRootTabByIndex(tabIndex);
+      // Do not pop to first when the tabs are bottom sheets
+      if ((tab != RootTab.Assistant) && (tab != RootTab.Wallet)) {
+        Navigator.of(context, rootNavigator: true).popUntil((route) => route.isFirst);
+      }
       _selectTab(tabIndex);
     }
   }


### PR DESCRIPTION
## Description
Do not pop to home panel when switching tabs to Assistant or Wallet.

**Fixes #5368**