### PR TITLE
Issue 5434. Use Result variable from evaluate() function to obtain resourceIds in survey

### DIFF
--- a/lib/ui/gbv/GBVSituationStepPanel.dart
+++ b/lib/ui/gbv/GBVSituationStepPanel.dart
@@ -108,31 +108,28 @@ class _GBVSituationStepPanelState extends State<GBVSituationStepPanel> {
       child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
         if (stepIconWidget != null)
           Padding(padding: EdgeInsets.only(right: 18), child:
-          stepIconWidget
+            stepIconWidget
           ),
         Expanded(child:
-        Text(question.moreInfo ?? '', style: Styles().textStyles.getTextStyle('widget.description.regular'))),
+          Text(question.moreInfo ?? '', style: Styles().textStyles.getTextStyle('widget.description.regular'))),
       ],),
     );
   }
 
   Widget _allowSkipButton(question) {
     String skipText = question.extras["skip_text"] ?? 'Skip this question';
-    return
-      Align(alignment: Alignment.centerRight, child:
+    return Align(alignment: Alignment.centerRight, child:
       TextButton(onPressed: () => _selectOption('__skipped__'), child:
-      Text(skipText, style: Styles().textStyles.getTextStyle('widget.detail.regular.underline'),
+        Text(skipText, style: Styles().textStyles.getTextStyle('widget.detail.regular.underline'),),
       ),
-      ),
-      );
+    );
   }
 
-  Widget get _loadingProgressIndicator =>
-      Center(child:
-      Padding(padding: const EdgeInsets.only(top: 24.0), child:
+  Widget get _loadingProgressIndicator => Center(child:
+    Padding(padding: const EdgeInsets.only(top: 24.0), child:
       CircularProgressIndicator(color: Styles().colors.fillColorSecondary)
-      )
-      );
+    ),
+  );
 
   Widget get _stepProgressIndicator => LinearProgressIndicator(
     value: (_stepHistory.length) / 5,
@@ -164,10 +161,10 @@ class _GBVSituationStepPanelState extends State<GBVSituationStepPanel> {
   }
 
   Widget _buildIconContainer(String imageName, Color bgColor) {
-    return Container(width: 67, height: 67,
-      decoration: BoxDecoration(color: bgColor, shape: BoxShape.circle,),
-      child: Center(
-          child: Styles().images.getImage(imageName, excludeFromSemantics: true, size: 36, fit: BoxFit.contain, color: Colors.white) ?? Container()),
+    return Container(width: 67, height: 67, decoration: BoxDecoration(color: bgColor, shape: BoxShape.circle,), child:
+      Center(child:
+        Styles().images.getImage(imageName, excludeFromSemantics: true, size: 36, fit: BoxFit.contain, color: Colors.white) ?? Container()
+      ),
     );
   }
 
@@ -297,31 +294,29 @@ class _GBVSituationStepPanelState extends State<GBVSituationStepPanel> {
   }
 
   String get _resourceListTitle =>
-      Localization().getStringEx('panel.sexual_misconduct.survey_result.title', 'Your Top Resources');
+    Localization().getStringEx('panel.sexual_misconduct.survey_result.title', 'Your Top Resources');
 
   String get _resourceListDescription => Localization().getStringEx(
-      'panel.sexual_misconduct.survey_result.description',
-      'Based on what you shared, here are some options that may help. '
-          'You’re in control of what happens next—take your time and explore what feels right. '
-          'You’re not alone, and support is available if you need it.'
+    'panel.sexual_misconduct.survey_result.description',
+    'Based on what you shared, here are some options that may help. '
+      'You’re in control of what happens next—take your time and explore what feels right. '
+      'You’re not alone, and support is available if you need it.'
   );
 
-  Widget get _errorContent =>
-      Center(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 28),
-          child: Text(
-            Localization().getStringEx('panel.sexual_misconduct.survey_result.error', 'Failed to load survey.'),
-            textAlign: TextAlign.center, style: Styles().textStyles.getTextStyle("widget.message.medium.thin"),
-          ),
-        ),
-      );
+  Widget get _errorContent => Center(child:
+    Padding(padding: const EdgeInsets.symmetric(horizontal: 28), child:
+      Text(Localization().getStringEx('panel.sexual_misconduct.survey_result.error', 'Failed to load survey.'),
+        textAlign: TextAlign.center,
+        style: Styles().textStyles.getTextStyle("widget.message.medium.thin"),
+      ),
+    ),
+  );
 
-  Widget get _loadingContent =>
-      Column(
-        children: [
-          const Expanded(flex: 1, child: SizedBox()),
-          SizedBox(width: 32, height: 32, child: CircularProgressIndicator(color: Styles().colors.fillColorSecondary, strokeWidth: 3,),),
-          const Expanded(flex: 2, child: SizedBox())],
-      );
+  Widget get _loadingContent => Column(children: [
+    const Expanded(flex: 1, child: SizedBox()),
+    SizedBox(width: 32, height: 32, child:
+      CircularProgressIndicator(color: Styles().colors.fillColorSecondary, strokeWidth: 3,),
+    ),
+    const Expanded(flex: 2, child: SizedBox())],
+  );
 }


### PR DESCRIPTION
## Description
A minor change (lines 213-217) to how resource_ids are obtained. The Surveys().evaluate() function in _showResults() returns a certain ordering of resources. Before, we were pulling these directly from a list that defined explicit ordering in the db. Now it pulls from a list that is created as a result of rules defined in the db. 

**Fixes #5434 **

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Immediately
- [ ] Within a week
- [x] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [ ] I have updated the [CHANGELOG](../CHANGELOG.md).
- [ ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)

