### PR TITLE
Assistant: read the query timeout from the app config [#5493]

### DIFF
--- a/lib/service/Assistant.dart
+++ b/lib/service/Assistant.dart
@@ -389,7 +389,10 @@ class Assistant with Service, NotificationsListener implements ContentItemCatego
 
     try {
       String? json = JsonUtils.encode(body);
-      Response? response = await Network().post(url, auth: Auth2(), headers: headers, body: json, timeout: 120);
+      int? requestTimeout = Config().assistantQueryRequestTimeout;
+      Response? response = await ((requestTimeout != null) ?
+        Network().post(url, auth: Auth2(), headers: headers, body: json, timeout: requestTimeout) :
+        Network().post(url, auth: Auth2(), headers: headers, body: json));
       int? responseCode = response?.statusCode;
       String? responseString = response?.body;
       if (responseCode == 200) {

--- a/lib/service/Config.dart
+++ b/lib/service/Config.dart
@@ -253,6 +253,9 @@ class Config extends rokwire.Config {
 
   int get inAppNotificationToastTimeout   => JsonUtils.intValue(settings['inAppNotificationToastTimeout']) ?? 6;
 
+  Map<String, dynamic> get assistantSettings      => JsonUtils.mapValue(settings['assistant']) ?? {};
+  int? get assistantQueryRequestTimeout           => JsonUtils.intValue(assistantSettings['queryRequestTimeout']);
+
   @override
   int get refreshTimeout=> kReleaseMode ? super.refreshTimeout : 0;
 


### PR DESCRIPTION
## Description
Assistant: read the query timeout from the app config.

**Fixes #5493**