### PR TITLE
Issue/5858 my courses calendar view

### DIFF
--- a/lib/ext/StudentCourse.dart
+++ b/lib/ext/StudentCourse.dart
@@ -188,10 +188,13 @@ extension StudentCourseSectionExt on StudentCourseSection {
     return result;
   }
 
-  int? get startTimeMinutes {
-    if ((startTime != null) && (4 <= startTime!.length)) {
-      int? hours = int.tryParse(startTime!.substring(0, 2));
-      int? minutes = int.tryParse(startTime!.substring(2, 4));
+  int? get startTimeMinutes => _parseTimeMinutes(startTime);
+  int? get endTimeMinutes => _parseTimeMinutes(endTime);
+
+  static int? _parseTimeMinutes(String? time) {
+    if ((time != null) && (4 <= time.length)) {
+      int? hours = int.tryParse(time.substring(0, 2));
+      int? minutes = int.tryParse(time.substring(2, 4));
       if ((hours != null) && (minutes != null)) {
         return (hours * 60) + minutes;
       }

--- a/lib/ui/academics/student_courses/StudentCoursesCalendarContentWidget.dart
+++ b/lib/ui/academics/student_courses/StudentCoursesCalendarContentWidget.dart
@@ -147,9 +147,10 @@ class _StudentCoursesCalendarContentWidgetState extends State<StudentCoursesCale
     for (StudentCourse course in widget.courses ?? <StudentCourse>[]) {
       int? startMinutes = course.section?.startTimeMinutes;
       if (startMinutes != null) {
+        int durationMinutes = StudentCoursesCalendarLayout.resolveDurationMinutes(startMinutes: startMinutes, endMinutes: course.section?.endTimeMinutes);
         for (int weekday in course.section?.weekdays ?? <int>[]) {
           blocksByWeekday.putIfAbsent(weekday, () => <StudentCourseBlock>[]).add(
-            StudentCourseBlock(course: course, startMinutes: startMinutes, durationMinutes: StudentCoursesCalendarLayout.fixedDurationMinutes)
+            StudentCourseBlock(course: course, startMinutes: startMinutes, durationMinutes: durationMinutes)
           );
         }
       }

--- a/lib/ui/academics/student_courses/StudentCoursesCalendarLayout.dart
+++ b/lib/ui/academics/student_courses/StudentCoursesCalendarLayout.dart
@@ -69,10 +69,19 @@ class StudentCoursesCalendarLayout {
   }
 
   ///
-  /// The backend always sends equal start/end times, so a real end time is derived as start + fixedDurationMinutes for display.
+  /// The backend usually sends an end time equal to the start time, in which case
+  /// fixedDurationMinutes is used as a fallback. If end time is after start time, the
+  /// real duration is used instead.
   ///
-  static String displayTimeRange(int startMinutes) {
-    int endMinutes = startMinutes + fixedDurationMinutes;
+  static int resolveDurationMinutes({required int startMinutes, int? endMinutes}) {
+    if ((endMinutes != null) && (startMinutes < endMinutes)) {
+      return endMinutes - startMinutes;
+    }
+    return fixedDurationMinutes;
+  }
+
+  static String displayTimeRange({required int startMinutes, required int durationMinutes}) {
+    int endMinutes = startMinutes + durationMinutes;
     return '${_formatClockMinutes(startMinutes, includeIndicator: false)}-${_formatClockMinutes(endMinutes, includeIndicator: true)}';
   }
 

--- a/lib/ui/home/HomeStudentCoursesWidget.dart
+++ b/lib/ui/home/HomeStudentCoursesWidget.dart
@@ -416,7 +416,7 @@ class _HomeStudentCoursesCalendarContentWidgetState extends State<_HomeStudentCo
   static const double _headerHeight = 32;
   static const double _gridTopPadding = 8;
   static const double _timeColumnGap = 8;
-  static const double _closingRowHeight = 16;
+  static const double _closingRowHeight = _minHourHeight;
 
   double _hourHeight = _minHourHeight;
 
@@ -450,6 +450,7 @@ class _HomeStudentCoursesCalendarContentWidgetState extends State<_HomeStudentCo
     double targetCardHeight = StudentCourseCard.height(context);
     double chromeHeight = _headerHeight + _gridTopPadding + _cardPadding + _closingRowHeight;
     _hourHeight = math.max((targetCardHeight - chromeHeight) / visibleHourCount, _minHourHeight);
+    double gridHeight = visibleHourCount * _hourHeight;
 
     return Container(
       clipBehavior: Clip.antiAlias,
@@ -460,7 +461,7 @@ class _HomeStudentCoursesCalendarContentWidgetState extends State<_HomeStudentCo
           Row(crossAxisAlignment: CrossAxisAlignment.start, children: <Widget>[
             _buildTimeColumn(),
             SizedBox(width: _timeColumnGap),
-            Expanded(child: SizedBox(height: visibleHourCount * _hourHeight, child: _buildDayColumn())),
+            Expanded(child: SizedBox(height: gridHeight + _closingRowHeight, child: _buildDayColumn())),
           ]),
         ),
       ]),
@@ -512,7 +513,7 @@ class _HomeStudentCoursesCalendarContentWidgetState extends State<_HomeStudentCo
       if ((startMinutes != null) && matchesWeekday) {
         int durationMinutes = StudentCoursesCalendarLayout.resolveDurationMinutes(startMinutes: startMinutes, endMinutes: course.section?.endTimeMinutes);
         StudentCourseBlock block = StudentCourseBlock(course: course, startMinutes: startMinutes, durationMinutes: durationMinutes);
-        if ((block.startMinutes < (_endHour * 60)) && (block.endMinutes > (_startHour * 60))) {
+        if ((block.startMinutes < ((_endHour + 1) * 60)) && (block.endMinutes > (_startHour * 60))) {
           blocks.add(block);
         }
       }
@@ -553,14 +554,31 @@ class _HomeStudentCoursesCalendarContentWidgetState extends State<_HomeStudentCo
     );
   }
 
+  double _minutesToOffset(double minutes) {
+    double windowStartMinutes = (_startHour * 60).toDouble();
+    double windowFullEndMinutes = (_endHour * 60).toDouble();
+    double windowOverflowEndMinutes = windowFullEndMinutes + 60;
+
+    double clampedMinutes = minutes.clamp(windowStartMinutes, windowOverflowEndMinutes);
+    if (clampedMinutes <= windowFullEndMinutes) {
+      return ((clampedMinutes - windowStartMinutes) / 60.0) * _hourHeight;
+    }
+    else {
+      double fullScaleHeight = ((windowFullEndMinutes - windowStartMinutes) / 60.0) * _hourHeight;
+      return fullScaleHeight + ((clampedMinutes - windowFullEndMinutes) / 60.0) * _closingRowHeight;
+    }
+  }
+
   Widget _buildCourseBlock(StudentCourseBlock block, {required double dayWidth}) {
     double columnWidth = dayWidth / block.columnCount;
-    double windowStartMinutes = (_startHour * 60).toDouble();
+    double top = _minutesToOffset(block.startMinutes.toDouble());
+    double bottom = _minutesToOffset(block.endMinutes.toDouble());
+
     return Positioned(
-      top: ((block.startMinutes - windowStartMinutes) / 60.0) * _hourHeight,
+      top: top,
       left: block.column * columnWidth,
       width: columnWidth,
-      height: (block.durationMinutes / 60.0) * _hourHeight,
+      height: math.max(bottom - top, 0),
       child: Padding(padding: EdgeInsets.all(1), child:
         InkWell(onTap: () => _onTapCourse(block.course), child:
           Container(

--- a/lib/ui/home/HomeStudentCoursesWidget.dart
+++ b/lib/ui/home/HomeStudentCoursesWidget.dart
@@ -510,7 +510,8 @@ class _HomeStudentCoursesCalendarContentWidgetState extends State<_HomeStudentCo
       int? startMinutes = course.section?.startTimeMinutes;
       bool matchesWeekday = course.section?.weekdays.contains(widget.weekday) ?? false;
       if ((startMinutes != null) && matchesWeekday) {
-        StudentCourseBlock block = StudentCourseBlock(course: course, startMinutes: startMinutes, durationMinutes: StudentCoursesCalendarLayout.fixedDurationMinutes);
+        int durationMinutes = StudentCoursesCalendarLayout.resolveDurationMinutes(startMinutes: startMinutes, endMinutes: course.section?.endTimeMinutes);
+        StudentCourseBlock block = StudentCourseBlock(course: course, startMinutes: startMinutes, durationMinutes: durationMinutes);
         if ((block.startMinutes < (_endHour * 60)) && (block.endMinutes > (_startHour * 60))) {
           blocks.add(block);
         }
@@ -578,7 +579,7 @@ class _HomeStudentCoursesCalendarContentWidgetState extends State<_HomeStudentCo
   }
 
   Widget _buildCourseBlockText(StudentCourseBlock block) {
-    String timeRange = StudentCoursesCalendarLayout.displayTimeRange(block.startMinutes);
+    String timeRange = StudentCoursesCalendarLayout.displayTimeRange(startMinutes: block.startMinutes, durationMinutes: block.durationMinutes);
     return RichText(maxLines: 1, overflow: TextOverflow.ellipsis, text: TextSpan(children: <TextSpan>[
       TextSpan(text: block.course.shortName ?? (block.course.title ?? ''), style: Styles().textStyles.getTextStyle('widget.message.tiny.fat')),
       TextSpan(text: ' | $timeRange', style: Styles().textStyles.getTextStyle('widget.message.tiny')),


### PR DESCRIPTION
## Description
Use default duration of 60 minutes for courses that have equal start and end times. Otherwise, use end - start time to calculate the duration. Fix colors for courses that exceed 4PM in the favorite widget

**Fixes #5858**