### PR TITLE
Issue/5915 day label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Don't display "TODAY" in My Courses Favorite widget. Only use the day of the week as a header [#5915](https://github.com/rokwire/illinois-app/issues/5915).
 
 ## [8.1.6] - 2026-07-28
 ### Changed

--- a/assets/strings.en.json
+++ b/assets/strings.en.json
@@ -4227,7 +4227,6 @@
     "widget.home.student_courses.text.failed.description": "You do not appear to be registered for any courses for the selected term.",
     "widget.home.student_courses.button.all.title": "View All",
     "widget.home.student_courses.button.all.hint": "Tap to view all courses",
-    "widget.home.student_courses.calendar.day.today.label": "TODAY",
     "widget.home.student_courses.calendar.day.monday.label": "MONDAY",
     "widget.home.student_courses.calendar.day.tuesday.label": "TUESDAY",
     "widget.home.student_courses.calendar.day.wednesday.label": "WEDNESDAY",

--- a/assets/strings.es.json
+++ b/assets/strings.es.json
@@ -4226,7 +4226,6 @@
     "widget.home.student_courses.text.failed.description": "Parece que no tiene cursos registrados para el término seleccionado.",
     "widget.home.student_courses.button.all.title": "Ver todo",
     "widget.home.student_courses.button.all.hint": "Toca para ver todos los cursos",
-    "widget.home.student_courses.calendar.day.today.label": "HOY",
     "widget.home.student_courses.calendar.day.monday.label": "LUNES",
     "widget.home.student_courses.calendar.day.tuesday.label": "MARTES",
     "widget.home.student_courses.calendar.day.wednesday.label": "MIÉRCOLES",

--- a/assets/strings.zh.json
+++ b/assets/strings.zh.json
@@ -4200,7 +4200,6 @@
 	"widget.home.student_courses.text.failed.description": "您似乎沒有為所選學期註冊的課程。",
 	"widget.home.student_courses.button.all.title": "查看全部",
 	"widget.home.student_courses.button.all.hint": "點擊查看所有課程",
-	"widget.home.student_courses.calendar.day.today.label": "今天",
 	"widget.home.student_courses.calendar.day.monday.label": "星期一",
 	"widget.home.student_courses.calendar.day.tuesday.label": "星期二",
 	"widget.home.student_courses.calendar.day.wednesday.label": "星期三",

--- a/lib/ui/home/HomeStudentCoursesWidget.dart
+++ b/lib/ui/home/HomeStudentCoursesWidget.dart
@@ -485,12 +485,7 @@ class _HomeStudentCoursesCalendarContentWidgetState extends State<_HomeStudentCo
     );
   }
 
-  String get _dayLabel {
-    bool isToday = (widget.weekday == DateTimeUni.nowUniOrLocal().weekday);
-    return isToday ?
-      Localization().getStringEx('widget.home.student_courses.calendar.day.today.label', 'TODAY') :
-      _weekdayName(widget.weekday);
-  }
+  String get _dayLabel => _weekdayName(widget.weekday);
 
   String _weekdayName(int weekday) {
     switch (weekday) {


### PR DESCRIPTION
## Description
Don't display "TODAY" in My Courses Favorite widget. Only use the day of the week as a header.

**Fixes #5915**