### PR TITLE
Issue/5991 image crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Do not report image exceptions as fatal errors [#5991](https://github.com/rokwire/illinois-app/issues/5991).
 
 ## [8.2.6] - 2026-08-19
 ### Fixed


### PR DESCRIPTION
## Description
Do not log images exceptions as fatal errors.

**Note**: Depends on https://github.com/rokwire/app-flutter-plugin/pull/723.

**Fixes #5991**